### PR TITLE
Fix SettingsError using ENV

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/app/app/core/config.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/core/config.py
@@ -1,7 +1,7 @@
 import secrets
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import AnyHttpUrl, BaseSettings, EmailStr, HttpUrl, PostgresDsn, validator
+from pydantic import AnyHttpUrl, BaseSettings, EmailStr, HttpUrl, PostgresDsn, validator, Field
 
 
 class Settings(BaseSettings):

--- a/{{cookiecutter.project_slug}}/backend/app/app/core/config.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/core/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
     # BACKEND_CORS_ORIGINS is a JSON-formatted list of origins
     # e.g: '["http://localhost", "http://localhost:4200", "http://localhost:3000", \
     # "http://localhost:8080", "http://local.dockertoolbox.tiangolo.com"]'
-    BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = []
+    BACKEND_CORS_ORIGINS: Union[str, List[AnyHttpUrl]] = Field(..., env="BACKEND_CORS_ORIGINS")
 
     @validator("BACKEND_CORS_ORIGINS", pre=True)
     def assemble_cors_origins(cls, v: Union[str, List[str]]) -> Union[List[str], str]:


### PR DESCRIPTION
### I usually use the Python shell when I'm developing, but I cannot simple open it using the env vars because I get this error:
    pydantic.env_settings.SettingsError: error parsing JSON for "BACKEND_CORS_ORIGINS"

### How to reproduce this error:
    cd backend/app/
    export $(grep -v '^#' ../../.env | tr -d ' ' | xargs) && poetry run python
> And inside the Python terminal:

    from app.core.config import settings